### PR TITLE
low memory version of cross entropy for large-vocab training

### DIFF
--- a/easy_context/low_mem_cross_ent.py
+++ b/easy_context/low_mem_cross_ent.py
@@ -1,0 +1,94 @@
+"""Low memory cross entropy without materilizing the logits
+
+This module enables long-context training of large vocab models, e.g., Gemma has 250K vocab and Llama 3 has 150K
+
+Yao Fu, University of Edinburgh
+yao.fu@ed.ac.uk
+"""
+
+import torch
+import torch.nn.functional as F
+
+
+def cross_ent_normal(x, weight, labels):
+    logits = torch.einsum("bsh, vh -> bsv", x, weight)
+    vocab = weight.size(0)
+    loss = F.cross_entropy(logits.view(-1, vocab), labels.view(-1))
+    return loss
+
+class LowMemLogitProjCrossEnt(torch.autograd.Function):
+    """Low memory implementation of logits projection plus cross entropy loss. 
+    Useful for reducing the peak memory when dealing with vocabulary larger than 100000
+
+    TODO: integrate this function into easy context
+
+    Two tricks used here 
+    1. Shard the data to reduce peak memory 
+    2. Do not save the logits 
+    """
+
+    @staticmethod
+    # @torch.compile() # Currently we do not use torch.compile because it uses additional memory
+    def forward(ctx, x: torch.Tensor, weight: torch.Tensor, labels: torch.Tensor, sp: int=4):
+        """
+        Args:
+            x: size = [batch, seqlen, hidden]
+            weight: size = [vocab, hidden]
+            labels: size = [batch, seqlen]
+        """
+        bsz, seqlen, hidden = x.size()
+        vocab = weight.size(0)
+        micro_seqlen = seqlen // sp
+        
+        loss = 0
+        for i in range(sp): # shard data along the sequence dimension
+            logits_i_slice = torch.einsum("bsh, vh -> bsv", x[:, micro_seqlen * i: micro_seqlen * (i + 1)], weight)
+            loss_i = F.cross_entropy(logits_i_slice.view(-1, vocab), labels[:, micro_seqlen * i: micro_seqlen * (i + 1)].view(-1))
+            loss = loss + loss_i
+
+        loss = loss / sp
+        ctx.save_for_backward(x, weight, labels) # because we do no save logits, we save memory
+        ctx.sp = sp
+        return loss
+
+    # @torch.compile()
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Manually calculate the gradient in a memory-efficient way
+        Ref: https://indii.org/blog/gradients-of-softmax-and-logsumexp/
+        """
+        x, weight, labels = ctx.saved_tensors
+        sp = ctx.sp
+        device = x.device
+        dtype = x.dtype
+        bsz, seqlen, hidden = x.size()
+        vocab, hidden = weight.size()
+        micro_seqlen = seqlen // sp
+
+        d_weight = torch.zeros_like(weight, device=weight.device)
+        d_x = []
+        for i in range(sp): # shard data along sequence dimension, reduce peak memory 
+            x_ = x[:, micro_seqlen * i: micro_seqlen * (i + 1)]
+            p = F.softmax(
+                    torch.einsum("blh, vh -> blv", x_, weight), 
+                    dim=-1
+                    )
+
+            # memory efficient in-place backprop
+            # loss -> d_logits
+            d_logits = -p.view(-1) # [b * l * v] 
+            labels_ = labels[:, micro_seqlen * i: micro_seqlen * (i + 1)].view(-1) # [b * l]
+            index = torch.arange(bsz * micro_seqlen, device=device) * vocab + labels_
+            source = torch.tensor([1] * bsz * micro_seqlen, dtype=dtype, device=device)
+            d_logits.index_add_(0, index, source)
+            d_logits = -d_logits.view(bsz, micro_seqlen, vocab) / (bsz * seqlen)
+
+            # d_logits -> d_x and d_weight
+            d_x.append(torch.einsum("blv, vh -> blh", d_logits, weight))
+            d_weight += torch.einsum("blv, blh -> vh", d_logits, x_)
+        
+        d_weight = grad_output * d_weight
+        d_x = grad_output * torch.concat(d_x, 1)
+        return d_x, d_weight, None, None
+
+low_mem_cross_ent = LowMemLogitProjCrossEnt.apply

--- a/easy_context/low_mem_cross_ent_tests/test_correctness.py
+++ b/easy_context/low_mem_cross_ent_tests/test_correctness.py
@@ -1,0 +1,81 @@
+"""Test the correctness (up to certain tolerance of numerical error) of low-memory cross-ent
+
+Yao Fu, University of Edinburgh
+yao.fu@ed.ac.uk
+"""
+
+import sys 
+sys.path.append("..")
+
+import torch 
+import torch.nn.functional as F
+from low_mem_cross_ent import low_mem_cross_ent, cross_ent_normal
+
+bsz = 1
+seqlen = 50000
+hidden = 4096
+vocab = 15000
+dtype = torch.bfloat16
+rtol=1e-05 # relative tolerance when comparing the gradients from two implementations
+atol=1e-07 # absolute tolerance when comparing the gradients from two implementations
+           # in Pytorch its default is 1e-8 but our implementation cannot pass this threshold
+           # 1e-7 seems to be the smallest rolerance we can pass
+
+x = torch.normal(mean=0, std=0.01, size=(bsz, seqlen, hidden), 
+    device="cuda", dtype=dtype, requires_grad=True)
+weight = torch.normal(mean=0, std=0.01, size=(vocab, hidden), 
+    device="cuda", dtype=dtype, requires_grad=True)
+labels = torch.randint(low=0, high=vocab - 1, size=(bsz, seqlen), device="cuda")
+
+loss_normal = cross_ent_normal(x, weight, labels)
+print("loss normal: %.4f" % loss_normal.cpu().item())
+loss_normal.backward()
+x_grad = x.grad.clone()
+weight_grad = weight.grad.clone()
+# print(x.grad)
+# print(weight.grad)
+
+
+# TODO: this one almost reduce memory to half. Maybe further increase sp
+x.grad = None
+weight.grad = None
+loss_low_mem = low_mem_cross_ent(x, weight, labels)
+print("loss low mem: %.4f" % loss_low_mem.cpu().item())
+loss_low_mem.backward()
+# print(x.grad)
+# print(weight.grad) 
+
+## Test implementation by asserting close
+assert(torch.allclose(x_grad, x.grad, rtol=rtol, atol=atol))
+assert(torch.allclose(weight_grad, weight.grad, rtol=rtol, atol=atol))
+print("PASS: gradients from normal computation and low memory computation are close.")
+
+
+# #### Test gradient of logits
+# x.grad = None
+# weight.grad = None
+# logits = torch.einsum("bsh, vh -> bsv", x, weight)
+# loss = F.cross_entropy(logits.view(-1, vocab), labels.view(-1))
+# d_logits = torch.autograd.grad(loss, logits)
+# p = F.softmax(torch.einsum("blh, vh -> blv", x, weight), dim=-1)
+# p_ = p / (bsz * seqlen)
+
+# #### test index add 
+# x = torch.tensor([1, 2, 3, 4, 5, 6, 7])
+# index = torch.tensor([1, 3, 4])
+# source = torch.tensor([1, 1, 1])
+# x.index_add_(dim=0, index=index, source=source)
+
+# #### test index add 2 
+# sp = 4
+# micro_seqlen = seqlen // sp
+# p = torch.normal(mean=0, std=0.01, size=(bsz, micro_seqlen, vocab), 
+#     device="cuda", dtype=torch.bfloat16)
+# labels_ = labels[:, :micro_seqlen].view(-1)
+# index = torch.arange(bsz * micro_seqlen, device="cuda") * vocab
+# index += labels_
+# d_logits = -p.view(-1)
+# source = torch.tensor([1] * bsz * micro_seqlen, dtype=torch.bfloat16, device="cuda")
+# d_logits.index_add_(0, index, source)
+# d_logits = d_logits.view(bsz, micro_seqlen, vocab)
+

--- a/easy_context/low_mem_cross_ent_tests/test_mem_and_speed.py
+++ b/easy_context/low_mem_cross_ent_tests/test_mem_and_speed.py
@@ -1,0 +1,80 @@
+"""Test the memory and speed and MFU of low memory cross entropy
+
+Yao Fu, University of Edinburgh
+yao.fu@ed.ac.uk
+
+bf16, seqlen=50000, vocab=150000, without torch.compile
+|          | normal | low_mem | -     |
+| sp       | -      | 4       | 16    |
+| peak mem | 43.4G  | 18.5G   | 8.1G  |
+| forward  | 0.307  | 0.310   | 0.315 |
+| backward | 0.631  | 0.896   | 0.914 | 
+| MFU      | 0.57   | 0.45    | 0.44  |
+
+NOTE: tried torch.compile and it takes significantly larger memory, so do not use
+TODO: profile and check why backward is slower
+"""
+import sys 
+sys.path.append("..")
+
+import torch 
+import numpy as np 
+import torch.nn.functional as F
+from low_mem_cross_ent import low_mem_cross_ent, cross_ent_normal
+
+implementation = "low_mem" # "normal", "low_mem"
+device_type = "A100"
+bsz = 1
+seqlen = 50000
+hidden = 4096
+vocab = 150000
+sp=16
+dtype = torch.bfloat16
+# dtype = torch.float
+G = 1024 ** 3
+T = 1024 ** 4
+
+x = torch.normal(mean=0, std=0.01, size=(bsz, seqlen, hidden), 
+    device="cuda", dtype=dtype, requires_grad=True)
+weight = torch.normal(mean=0, std=0.01, size=(vocab, hidden), 
+    device="cuda", dtype=dtype, requires_grad=True)
+labels = torch.randint(low=0, high=vocab - 1, size=(bsz, seqlen), device="cuda")
+
+def timed(fn):
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    result = fn()
+    end.record()
+    torch.cuda.synchronize()
+    return result, start.elapsed_time(end) / 1000
+
+n_runs = 50
+flop = 6 * bsz * seqlen * hidden * vocab
+if(implementation == "normal"):
+    forward_times, backward_times = [], []
+    for _ in range(n_runs): 
+        loss_normal, time_elapse = timed(lambda: cross_ent_normal(x, weight, labels))
+        forward_times.append(time_elapse)
+        _, time_elapse = timed(lambda: loss_normal.backward())
+        backward_times.append(time_elapse)
+    mem = torch.cuda.max_memory_allocated()
+elif(implementation == "low_mem"):
+    forward_times, backward_times = [], []
+    for _ in range(n_runs): 
+        loss_low_mem, time_elapse = timed(lambda: low_mem_cross_ent(x, weight, labels, sp))
+        forward_times.append(time_elapse)
+        _, time_elapse = timed(lambda: loss_low_mem.backward())
+        backward_times.append(time_elapse)
+    mem = torch.cuda.max_memory_allocated()
+else: raise NameError("Implementation %s not recognized" % implementation)
+
+forward_time = np.median(forward_times)
+backward_time = np.median(backward_times)
+flops = (flop / T) / (forward_time + backward_time)
+if(device_type == "A100"):
+    device_flop = 312
+else: raise NameError("device %s not recognized" % device_type)
+
+print("%s, peak memory %.1fG, forward time %.4f, backward time %.4f, flops %.2fT, util %.2f" % 
+    (implementation, mem / G, forward_time, backward_time, flops, flops / device_flop))


### PR DESCRIPTION
This PR enables the long-context training of large vocab models like Gemma2 (250K vocab) and llama3 (150K vocab). 

They key here is instead to fully materializing the logits matrix and its gradients, we do it chunk-by-chunk similar to sequence parallelism, but done in a for loop in every single device. 

I have also added test scripts to measure its correctness, memory and speed. Currently, compared to standard implementation, the MFU reduces from 57 to 45, but the peak memory also reduces from 43G to 8G